### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately. Do not open a public issue or disclose the vulnerability publicly until we have coordinated a fix.
+
+The preferred way to report is GitHub's private vulnerability reporting: on the affected repository, go to the **Security** tab and click **Report a vulnerability** (or open `https://github.com/getAlby/builder-skill/security/advisories/new`). Alternatively, you can email [security@getalby.com](mailto:security@getalby.com).
+
+Please include the affected version or component, the potential impact, and clear steps to reproduce the issue. We will acknowledge your report and keep you informed as we investigate and address it.


### PR DESCRIPTION
## Summary

- add a `SECURITY.md` with private vulnerability reporting guidance
- document GitHub private vulnerability reporting and `security@getalby.com` as contact options

## Verification

- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security policy covering vulnerability reporting channels and required report details.
  * Documented how security investigations and communications are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->